### PR TITLE
Avoid a memory leak when storing past events

### DIFF
--- a/src/subscriptions/subscriptionBackfill.ts
+++ b/src/subscriptions/subscriptionBackfill.ts
@@ -126,6 +126,9 @@ export function makeBackfiller(senders: JsonRpcSenders) {
     fromBlockInclusive: number,
     toBlockExclusive: number,
   ): Promise<NewHeadsEvent[]> {
+    if (fromBlockInclusive >= toBlockExclusive) {
+      return [];
+    }
     const batchParts: BatchPart[] = [];
     for (let i = fromBlockInclusive; i < toBlockExclusive; i++) {
       batchParts.push({
@@ -199,11 +202,14 @@ export function makeBackfiller(senders: JsonRpcSenders) {
     return Number.NEGATIVE_INFINITY;
   }
 
-  function getLogsInRange(
+  async function getLogsInRange(
     filter: LogsSubscriptionFilter,
     fromBlockInclusive: number,
     toBlockExclusive: number,
   ): Promise<LogsEvent[]> {
+    if (fromBlockInclusive >= toBlockExclusive) {
+      return [];
+    }
     const rangeFilter: GetLogsOptions = {
       ...filter,
       fromBlock: toHex(fromBlockInclusive),


### PR DESCRIPTION
Our subscriptions need to store events they have sent recently so if
they need to be reconnected we can detect re-orgs that occurred while
they are down. These events were previously stored in buffers that grew
without bound. Now make sure to evict old values that we no longer need.