### PR TITLE
Add top-level ethGasStation api

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { callWhenDone } from "./util/promises";
 import { makeAlchemyContext } from "./web3-adapter/alchemyContext";
 import { patchEnableCustomRPC } from "./web3-adapter/customRPC";
 import { patchEthFeeHistoryMethod } from "./web3-adapter/eth_feeHistory";
+import { patchEthGasStation } from "./web3-adapter/eth_gasStation";
 import { patchEthMaxPriorityFeePerGasMethod } from "./web3-adapter/eth_maxPriorityFeePerGas";
 
 const DEFAULT_MAX_RETRIES = 3;
@@ -238,6 +239,7 @@ export function createAlchemyWeb3(
   patchEnableCustomRPC(alchemyWeb3);
   patchEthFeeHistoryMethod(alchemyWeb3);
   patchEthMaxPriorityFeePerGasMethod(alchemyWeb3);
+  patchEthGasStation(alchemyWeb3);
   return alchemyWeb3;
 }
 

--- a/src/web3-adapter/eth_gasStation.ts
+++ b/src/web3-adapter/eth_gasStation.ts
@@ -1,0 +1,29 @@
+import https from "https";
+
+export function patchEthGasStation(web3: any): void {
+  web3.ethGasSation = (apiKey: string) => {
+    return new Promise((resolve, reject) => {
+      https.get(
+        {
+          hostname: "data-api.defipulse.com",
+          path: "/api/v1/egs/api/ethgasAPI.json",
+          search: `?api-key=${apiKey}`,
+        },
+        (response) => {
+          let data = "";
+          response.on("data", (chunk) => {
+            data += chunk;
+          });
+
+          response.on("end", () => {
+            resolve(data);
+          });
+
+          response.on("error", (err) => {
+            reject(err);
+          });
+        },
+      );
+    });
+  };
+}


### PR DESCRIPTION
Adds `web3.ethGasSation` method. The motivation for adding this method is so that I can complete a few Alchemy tutorials entirely in alchemy-web3.