### PR TITLE
Fixed bug in web3.alchemy.getTokenBalances that sometimes resulted in incorrect balances

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "web3-core-method": "1.5.2",
     "web3-core-subscriptions": "1.5.2",
     "web3-eth": "1.5.2",
+    "web3-eth-abi": "1.5.2",
     "web3-utils": "1.5.2",
     "websocket": "^1.0.28"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@ import Web3 from "web3";
 import { Log, LogsOptions, Transaction } from "web3-core";
 import web3CoreSubscriptions, { Subscription } from "web3-core-subscriptions";
 import { BlockHeader, Eth, Syncing } from "web3-eth";
-import { hexToNumberString, toHex } from "web3-utils";
+import { decodeParameter } from "web3-eth-abi";
+import { toHex } from "web3-utils";
 import {
   AlchemyWeb3Config,
   FullConfig,
@@ -283,7 +284,10 @@ function processTokenBalanceResponse(
   // Convert token balance fields from hex-string to decimal-string.
   const fixedTokenBalances = rawResponse.tokenBalances.map((balance) =>
     balance.tokenBalance != null
-      ? { ...balance, tokenBalance: hexToNumberString(balance.tokenBalance) }
+      ? {
+          ...balance,
+          tokenBalance: decodeParameter("uint256", balance.tokenBalance),
+        }
       : balance,
   );
   return { ...rawResponse, tokenBalances: fixedTokenBalances };

--- a/src/types/web3-eth-abi.d.ts
+++ b/src/types/web3-eth-abi.d.ts
@@ -1,0 +1,11 @@
+import { AbiCoder } from "web3-eth-abi";
+
+declare class SpecificAbiCoder extends AbiCoder {
+  public decodeParameter(type: "uint256", hex: string): string;
+  public decodeParameter(type: any, hex: string): unknown;
+}
+
+declare module "web3-eth-abi" {
+  const coder: SpecificAbiCoder;
+  export = coder;
+}


### PR DESCRIPTION
Some ERC-20 compatible contracts slightly deviates from the standard by returning more than 256 bits of data when the `balanceOf(address)` method is called. This deviation is never noticed when calling the method through `eth_call`, as the ABI specifies that the return type is `uint256`. 

However, when fetching this information through `web3.alchemy.getTokenBalances`, the entirety of the return data is converted into a number, causing the contracts deviating from the standard to return incorrect balances. Due to more than 256 bits of data being considered when converting between the returned data and the balance, this number is usually much larger than what one would expect.

This PR fixes the above problem by only considering the first 256 bits of the return value. I've spoken with Elan on your Discord about this issue, where I proposed to submit this PR. The fix has been confirmed working in our production environment.

The type declaration file (.d.ts) is needed because web3-eth-abi has incorrect typing. Namely, there are two issues:
- An instance of AbiCoder is exported, not the class itself
- The return type of decodeParameter is incorrect