### PR TITLE
Avoid spurious "unhandled promise rejection" messages

### DIFF
--- a/src/util/promises.ts
+++ b/src/util/promises.ts
@@ -27,8 +27,12 @@ export function callWhenDone<T>(
   callback: Web3Callback<T>,
 ): void {
   promise.then(
-    (result) => callback(null, result),
-    (error) => callback(error),
+    (result) => {
+      callback(null, result);
+    },
+    (error) => {
+      callback(error);
+    },
   );
 }
 


### PR DESCRIPTION
Cleans up an unintended interaction when handling Node-style callback
that return rejected promises. Such callbacks would lead to "unhandled
promise rejection" messages in our utility function `callWhenDone`.