### PR TITLE
Add Order to Get Asset Transfers Alchemy Web3

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ An object with the following fields:
 
 - `fromBlock`: Optional inclusive from hex string block (default latest)
 - `toBlock`: Optional inclusive to hex string block (default latest)
-- `order`: Optional string that specifies the ordering of the results. Must be one of ["asc", "desc"] (default "asc")
+- `order`: Optional string that specifies the ordering of the results by block number. Must be one of ["asc", "desc"] (default "asc")
 - `fromAddress`: Optional from hex string address (default wildcard)
 - `toAddress`: Optional to hex string address (default wildcard)
   NOTE: `fromAddress` is ANDed with `toAddress`

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ An object with the following fields:
 
 - `fromBlock`: Optional inclusive from hex string block (default latest)
 - `toBlock`: Optional inclusive to hex string block (default latest)
+- `order`: Optional string that specifies the ordering of the results. Must be one of ["asc", "desc"] (default "asc")
 - `fromAddress`: Optional from hex string address (default wildcard)
 - `toAddress`: Optional to hex string address (default wildcard)
   NOTE: `fromAddress` is ANDed with `toAddress`
@@ -379,11 +380,14 @@ An object with the following fields:
 **Example**
 
 Method call
+
 ```
 web3.eth.getFeeHistory(4, "latest", [25, 50, 75]).then(console.log);
 
 ```
+
 Logged response
+
 ```
 {
   oldestBlock: 12930639,
@@ -413,10 +417,13 @@ A hex, which is the `maxPriorityFeePerGas` suggestion. You can plug this directl
 **Example**
 
 Method call
+
 ```
 web3.eth.getMaxPriorityFeePerGas().then(console.log);
 ```
+
 Logged response
+
 ```
 0x560de0700
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,7 @@ export interface TokenMetadataResponse {
 export interface AssetTransfersParams {
   fromBlock?: string;
   toBlock?: string;
+  order?: AssetTransfersOrder;
   fromAddress?: string;
   toAddress?: string;
   contractAddresses?: string[];
@@ -102,6 +103,11 @@ export enum AssetTransfersCategory {
   ERC20 = "erc20",
   ERC721 = "erc721",
   ERC1155 = "erc1155",
+}
+
+export enum AssetTransfersOrder {
+  ASCENDING = "asc",
+  DESCENDING = "desc",
 }
 
 export interface AssetTransfersResponse {


### PR DESCRIPTION
# Background
We added ordering to the getAssetTransfers API recently this PR exposes the order parameter to our api.

# This Pull Request
This pull request adds a parameter to the exiting alchemy_getAssetTransfers method to our Alchemy Web 3 client.

# Test Plan

*Test using order permutations and ensuring results return*
## Ascending Order (asc)
<img width="526" alt="Screen Shot 2021-11-15 at 5 01 20 PM" src="https://user-images.githubusercontent.com/3498866/141866426-6c04e5c4-a271-4f00-8a6f-035ea7e97d1b.png">
<img width="583" alt="Screen Shot 2021-11-15 at 5 06 47 PM" src="https://user-images.githubusercontent.com/3498866/141866810-f507544d-61ce-4537-b89f-31b9fb2f7a37.png">

## Descending Order (desc)
<img width="535" alt="Screen Shot 2021-11-15 at 5 01 10 PM" src="https://user-images.githubusercontent.com/3498866/141866440-b88726bf-e5d4-47a1-becb-0bb103da1699.png">
<img width="615" alt="Screen Shot 2021-11-15 at 5 07 09 PM" src="https://user-images.githubusercontent.com/3498866/141866793-77fde6ab-cb20-4aa9-9bf9-dcb8f59c84af.png">

## No Order ("" -> defaults to asc)
<img width="527" alt="Screen Shot 2021-11-15 at 5 01 27 PM" src="https://user-images.githubusercontent.com/3498866/141866457-649a8e6c-1723-41fb-bd2f-96adfecd0e77.png">
<img width="604" alt="Screen Shot 2021-11-15 at 5 05 53 PM" src="https://user-images.githubusercontent.com/3498866/141866678-95f52b6d-9dfc-4288-a642-700c02cc53da.png">

## Bad Parameter
<img width="525" alt="Screen Shot 2021-11-15 at 5 03 57 PM" src="https://user-images.githubusercontent.com/3498866/141866497-ff93927d-5e36-46a3-b8c6-04f2e9318da6.png">
<img width="1437" alt="Screen Shot 2021-11-15 at 5 05 25 PM" src="https://user-images.githubusercontent.com/3498866/141866664-e809f0f4-3091-4847-830c-99c1679f1e72.png">