### PR TITLE
Update type for nft metadata response

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,7 +148,7 @@ export interface NftMetadataResponse {
   alchemyImageUri: string | null;
   name: string | null;
   description: string | null;
-  attributes: [Record<string, any>] | null;
+  attributes: Array<Record<string, any>>;
   rawMetadata: Record<string, any>;
 }
 


### PR DESCRIPTION
# Background
Fixes a type error on the nit metadata response internal object. [(Context)](https://alchemyinsights.slack.com/archives/C02L0TDK48N/p1639530301116400)

**Note for reviewers:** Interestingly the data that was returned just fine in both the before and after this fix. So before just blindly shipping this I'm going to investigate why. But I thought getting the fix out there earlier the better for review.

^ Update: Because our web3 playground evaluates all of the types from the library to any and the `callAlchemyMethod` in the web3 function just does a straight pass-through from the backend result the data would correctly propagate through in the test. _However, any consumers of the api could have a compiler error trying to access the objects in a real library given the types wouldn't match up._

# Testplan
With [web3 playground test that NFT metadata works as expected](https://github.com/OMGWINNING/web3-playground/blob/rohan/updatePlayground/src/index.ts)
<img width="719" alt="Screen Shot 2021-12-14 at 9 20 30 PM" src="https://user-images.githubusercontent.com/3498866/146123278-8d0f101c-b012-43f6-beae-aa6c69f07a5b.png">
