### PR TITLE
Add a REST handler for getNfts and getNftMetadata

### DIFF
--- a/src/alchemy-apis/types.ts
+++ b/src/alchemy-apis/types.ts
@@ -1,0 +1,142 @@
+export interface TokenAllowanceParams {
+  contract: string;
+  owner: string;
+  spender: string;
+}
+
+export type TokenAllowanceResponse = string;
+
+export interface TokenBalancesResponse {
+  address: string;
+  tokenBalances: TokenBalance[];
+}
+
+export type TokenBalance = TokenBalanceSuccess | TokenBalanceFailure;
+
+export interface TokenBalanceSuccess {
+  address: string;
+  tokenBalance: string;
+  error: null;
+}
+
+export interface TokenBalanceFailure {
+  address: string;
+  tokenBalance: null;
+  error: string;
+}
+
+export interface TokenMetadataResponse {
+  decimals: number | null;
+  logo: string | null;
+  name: string | null;
+  symbol: string | null;
+}
+
+export interface AssetTransfersParams {
+  fromBlock?: string;
+  toBlock?: string;
+  order?: AssetTransfersOrder;
+  fromAddress?: string;
+  toAddress?: string;
+  contractAddresses?: string[];
+  excludeZeroValue?: boolean;
+  maxCount?: number;
+  category?: AssetTransfersCategory[];
+  pageKey?: string;
+}
+
+export enum AssetTransfersCategory {
+  EXTERNAL = "external",
+  INTERNAL = "internal",
+  TOKEN = "token",
+  ERC20 = "erc20",
+  ERC721 = "erc721",
+  ERC1155 = "erc1155",
+}
+
+export enum AssetTransfersOrder {
+  ASCENDING = "asc",
+  DESCENDING = "desc",
+}
+
+export interface AssetTransfersResponse {
+  transfers: AssetTransfersResult[];
+  pageKey?: string;
+}
+
+export interface AssetTransfersResult {
+  category: AssetTransfersCategory;
+  blockNum: string;
+  from: string;
+  to: string | null;
+  value: number | null;
+  erc721TokenId: string | null;
+  erc1155Metadata: ERC1155Metadata[] | null;
+  asset: string | null;
+  hash: string;
+  rawContract: RawContract;
+}
+
+export interface NftMetadata {
+  image?: string;
+  attributes?: Array<Record<string, any>>;
+}
+
+export interface NftMedia {
+  uri?: string;
+}
+
+export interface NftContract {
+  address: string;
+}
+
+export interface NftId {
+  tokenId: string;
+  tokenMetadata?: NftTokenMetadata;
+}
+
+export interface NftTokenMetadata {
+  tokenType: "erc721" | "erc1155";
+}
+
+export interface GetNftMetadataParams {
+  contractAddress: string;
+  tokenId: string;
+  tokenType: "erc721" | "erc1155";
+}
+
+export interface GetNftMetadataResponse {
+  contract: NftContract;
+  id: NftId;
+  externalDomainViewUrl?: string | null;
+  media?: NftMedia;
+  alternateMedia?: NftMedia[];
+  metadata?: NftMetadata;
+}
+
+export interface GetNftsParams {
+  owner: string;
+  pageKey?: string;
+}
+
+export interface GetNftsResponse {
+  ownedNfts: Nft[];
+  pageKey?: string;
+  totalCount: number;
+}
+
+export interface Nft {
+  contract: NftContract;
+  id: NftId;
+}
+
+export interface ERC1155Metadata {
+  tokenId: string;
+  value: string;
+}
+
+export interface RawContract {
+  value: string | null;
+  address: string | null;
+  decimal: string | null;
+}

--- a/src/alchemy-apis/types.ts
+++ b/src/alchemy-apis/types.ts
@@ -52,6 +52,7 @@ export enum AssetTransfersCategory {
   ERC20 = "erc20",
   ERC721 = "erc721",
   ERC1155 = "erc1155",
+  SPECIALNFT = "specialnft",
 }
 
 export enum AssetTransfersOrder {
@@ -72,6 +73,7 @@ export interface AssetTransfersResult {
   value: number | null;
   erc721TokenId: string | null;
   erc1155Metadata: ERC1155Metadata[] | null;
+  tokenId: string | null;
   asset: string | null;
   hash: string;
   rawContract: RawContract;
@@ -102,15 +104,13 @@ export interface NftTokenMetadata {
 export interface GetNftMetadataParams {
   contractAddress: string;
   tokenId: string;
-  tokenType: "erc721" | "erc1155";
+  tokenType?: "erc721" | "erc1155";
 }
 
 export interface GetNftMetadataResponse {
   contract: NftContract;
   id: NftId;
-  externalDomainViewUrl?: string | null;
   media?: NftMedia;
-  alternateMedia?: NftMedia[];
   metadata?: NftMetadata;
 }
 

--- a/src/alchemy-apis/types.ts
+++ b/src/alchemy-apis/types.ts
@@ -117,6 +117,7 @@ export interface GetNftMetadataResponse {
 export interface GetNftsParams {
   owner: string;
   pageKey?: string;
+  contractAddresses?: string[];
 }
 
 export interface GetNftsResponse {

--- a/src/subscriptions/subscriptionBackfill.ts
+++ b/src/subscriptions/subscriptionBackfill.ts
@@ -65,7 +65,7 @@ export type Backfiller = ReturnType<typeof makeBackfiller>;
  */
 const MAX_BACKFILL_BLOCKS = 120;
 
-export function makeBackfiller(senders: JsonRpcSenders) {
+export function makeBackfiller(jsonRpcSenders: JsonRpcSenders) {
   return { getNewHeadsBackfill, getLogsBackfill };
 
   async function getNewHeadsBackfill(
@@ -136,12 +136,15 @@ export function makeBackfiller(senders: JsonRpcSenders) {
         params: [toHex(i), false],
       });
     }
-    const heads = await senders.sendBatch(batchParts);
+    const heads = await jsonRpcSenders.sendBatch(batchParts);
     return heads.map(toNewHeadsEvent);
   }
 
   async function getBlockByNumber(blockNumber: number): Promise<BlockHead> {
-    return senders.send("eth_getBlockByNumber", [toHex(blockNumber), false]);
+    return jsonRpcSenders.send("eth_getBlockByNumber", [
+      toHex(blockNumber),
+      false,
+    ]);
   }
 
   async function getLogsBackfill(
@@ -215,11 +218,11 @@ export function makeBackfiller(senders: JsonRpcSenders) {
       fromBlock: toHex(fromBlockInclusive),
       toBlock: toHex(toBlockExclusive - 1),
     };
-    return senders.send("eth_getLogs", [rangeFilter]);
+    return jsonRpcSenders.send("eth_getLogs", [rangeFilter]);
   }
 
   async function getBlockNumber(): Promise<number> {
-    const blockNumberHex: string = await senders.send("eth_blockNumber");
+    const blockNumberHex: string = await jsonRpcSenders.send("eth_blockNumber");
     return fromHex(blockNumberHex);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,7 +78,10 @@ export interface LegacyProvider {
 
 export type Web3Callback<T> = (error: Error | null, result?: T) => void;
 
-export type SendFunction = (method: string, params?: any[]) => Promise<any>;
+export type SendJsonRpcFunction = (
+  method: string,
+  params?: any[],
+) => Promise<any>;
 
 export interface TransactionsOptions {
   address?: string;

--- a/src/web3-adapter/alchemyContext.ts
+++ b/src/web3-adapter/alchemyContext.ts
@@ -3,21 +3,23 @@ import { w3cwebsocket } from "websocket";
 import { FullConfig, Provider } from "../types";
 import {
   JsonRpcSenders,
-  makePayloadFactory,
-  makeSenders,
+  makeJsonRpcPayloadFactory,
+  makeJsonRpcSenders,
 } from "../util/jsonRpc";
 import { VERSION } from "../version";
-import { makeHttpSender } from "./alchemySendHttp";
+import { makeJsonRpcHttpSender } from "./alchemySendHttp";
 import { makeWebSocketSender } from "./alchemySendWebSocket";
 import { makeAlchemyHttpProvider } from "./httpProvider";
-import { makePayloadSender } from "./sendPayload";
+import { makeJsonRpcPayloadSender } from "./sendJsonRpcPayload";
+import { makeRestPayloadSender, RestPayloadSender } from "./sendRestPayload";
 import { AlchemyWebSocketProvider } from "./webSocketProvider";
 
 const NODE_MAX_WS_FRAME_SIZE = 100 * 1024 * 1024; // 100 MB
 
 export interface AlchemyContext {
   provider: any;
-  senders: JsonRpcSenders;
+  restSender: RestPayloadSender;
+  jsonRpcSenders: JsonRpcSenders;
   setWriteProvider(provider: Provider | null | undefined): void;
 }
 
@@ -25,29 +27,43 @@ export function makeAlchemyContext(
   url: string,
   config: FullConfig,
 ): AlchemyContext {
-  const makePayload = makePayloadFactory();
+  const makeJsonRpcPayload = makeJsonRpcPayloadFactory();
+  const restSender = makeRestPayloadSender({
+    config,
+    url,
+  });
   if (/^https?:\/\//.test(url)) {
-    const alchemySend = makeHttpSender(url);
-    const { sendPayload, setWriteProvider } = makePayloadSender(
-      alchemySend,
+    const alchemySendJsonrRpc = makeJsonRpcHttpSender(url);
+    const { sendJsonRpcPayload, setWriteProvider } = makeJsonRpcPayloadSender(
+      alchemySendJsonrRpc,
       config,
     );
-    const senders = makeSenders(sendPayload, makePayload);
-    const provider = makeAlchemyHttpProvider(sendPayload);
-    return { provider, senders, setWriteProvider };
+    const jsonRpcSenders = makeJsonRpcSenders(
+      sendJsonRpcPayload,
+      makeJsonRpcPayload,
+    );
+    const provider = makeAlchemyHttpProvider(sendJsonRpcPayload);
+    return { provider, jsonRpcSenders, restSender, setWriteProvider };
   } else if (/^wss?:\/\//.test(url)) {
     const protocol = isAlchemyUrl(url) ? `alchemy-web3-${VERSION}` : undefined;
     const ws = new SturdyWebSocket(url, protocol, {
       wsConstructor: getWebSocketConstructor(),
     });
     const alchemySend = makeWebSocketSender(ws);
-    const { sendPayload, setWriteProvider } = makePayloadSender(
+    const { sendJsonRpcPayload, setWriteProvider } = makeJsonRpcPayloadSender(
       alchemySend,
       config,
     );
-    const senders = makeSenders(sendPayload, makePayload);
-    const provider = new AlchemyWebSocketProvider(ws, sendPayload, senders);
-    return { provider, senders, setWriteProvider };
+    const jsonRpcSenders = makeJsonRpcSenders(
+      sendJsonRpcPayload,
+      makeJsonRpcPayload,
+    );
+    const provider = new AlchemyWebSocketProvider(
+      ws,
+      sendJsonRpcPayload,
+      jsonRpcSenders,
+    );
+    return { provider, jsonRpcSenders, restSender, setWriteProvider };
   } else {
     throw new Error(
       `Alchemy URL protocol must be one of http, https, ws, or wss. Recieved: ${url}`,

--- a/src/web3-adapter/alchemySend.ts
+++ b/src/web3-adapter/alchemySend.ts
@@ -2,15 +2,15 @@ import SturdyWebSocket from "sturdy-websocket";
 import { SingleOrBatchRequest, SingleOrBatchResponse } from "../types";
 
 export interface AlchemySender {
-  alchemySend: AlchemySendFunction;
+  alchemySend: AlchemySendJsonRpcFunction;
   ws?: SturdyWebSocket;
 }
 
-export type AlchemySendFunction = (
+export type AlchemySendJsonRpcFunction = (
   request: SingleOrBatchRequest,
-) => Promise<AlchemySendResult>;
+) => Promise<AlchemySendJsonRpcResult>;
 
-export type AlchemySendResult =
+export type AlchemySendJsonRpcResult =
   | JsonRpcSendResult
   | RateLimitSendResult
   | NetworkErrorSendResult;

--- a/src/web3-adapter/alchemySendHttp.ts
+++ b/src/web3-adapter/alchemySendHttp.ts
@@ -1,6 +1,6 @@
 import fetchPonyfill from "fetch-ponyfill";
 import { VERSION } from "../version";
-import { AlchemySendFunction } from "./alchemySend";
+import { AlchemySendJsonRpcFunction } from "./alchemySend";
 
 const { fetch, Headers } = fetchPonyfill();
 
@@ -11,7 +11,7 @@ const ALCHEMY_HEADERS = new Headers({
 });
 const RATE_LIMIT_STATUS = 429;
 
-export function makeHttpSender(url: string): AlchemySendFunction {
+export function makeJsonRpcHttpSender(url: string): AlchemySendJsonRpcFunction {
   return async (request) => {
     const response = await fetch(url, {
       method: "POST",

--- a/src/web3-adapter/alchemySendWebSocket.ts
+++ b/src/web3-adapter/alchemySendWebSocket.ts
@@ -7,14 +7,19 @@ import {
   SingleOrBatchResponse,
   WebSocketMessage,
 } from "../types";
-import { AlchemySendFunction, AlchemySendResult } from "./alchemySend";
+import {
+  AlchemySendJsonRpcFunction,
+  AlchemySendJsonRpcResult,
+} from "./alchemySend";
 
 interface RequestContext {
   request: SingleOrBatchRequest;
-  resolve(response: AlchemySendResult): void;
+  resolve(response: AlchemySendJsonRpcResult): void;
 }
 
-export function makeWebSocketSender(ws: SturdyWebSocket): AlchemySendFunction {
+export function makeWebSocketSender(
+  ws: SturdyWebSocket,
+): AlchemySendJsonRpcFunction {
   const contextsById = new Map<JsonRpcId, RequestContext>();
   ws.addEventListener("message", (message) => {
     const response: WebSocketMessage = JSON.parse(message.data);

--- a/src/web3-adapter/httpProvider.ts
+++ b/src/web3-adapter/httpProvider.ts
@@ -4,17 +4,19 @@ import {
   Web3Callback,
 } from "../types";
 import { callWhenDone } from "../util/promises";
-import { SendPayloadFunction } from "./sendPayload";
+import { SendJsonRpcPayloadFunction } from "./sendJsonRpcPayload";
 
 /**
  * Returns a "provider" which can be passed to the Web3 constructor.
  */
-export function makeAlchemyHttpProvider(sendPayload: SendPayloadFunction) {
+export function makeAlchemyHttpProvider(
+  sendJsonRpcPayload: SendJsonRpcPayloadFunction,
+) {
   function send(
     payload: SingleOrBatchRequest,
     callback: Web3Callback<SingleOrBatchResponse>,
   ): void {
-    callWhenDone(sendPayload(payload), callback);
+    callWhenDone(sendJsonRpcPayload(payload), callback);
   }
   return { send };
 }

--- a/src/web3-adapter/sendRestPayload.ts
+++ b/src/web3-adapter/sendRestPayload.ts
@@ -1,0 +1,80 @@
+import fetchPonyfill from "fetch-ponyfill";
+import { FullConfig } from "../types";
+import { delay } from "../util/promises";
+
+export interface RestPayloadSender {
+  sendRestPayload: SendRestPayloadFunction;
+}
+
+export type SendRestPayloadFunction = (
+  path: string,
+  payload: Record<string, any>,
+) => Promise<any>;
+
+export interface RestPayloadConfig {
+  url: string;
+  config: FullConfig;
+}
+
+export function makeRestPayloadSender({
+  url,
+  config,
+}: RestPayloadConfig): RestPayloadSender {
+  // The rest payload sender only works for alchemy.com http endpoints.
+  let error: string | undefined;
+  if (/^wss?:\/\//.test(url)) {
+    error = "Alchemy rest endpoints are not available via websockets";
+  }
+  if (!url.includes("alchemy")) {
+    error =
+      "Alchemy specific rest endpoints are not available with a non Alchemy provider.";
+  }
+  if (url.includes("alchemyapi.io")) {
+    error =
+      "Alchemy specific rest endpoints are not available with our legacy endpoints on alchemyapi.io, please switch over to alchemy.com";
+  }
+
+  const urlObject = new URL(url);
+  const origin = urlObject.origin;
+  const apiKey = urlObject.pathname.substring(
+    urlObject.pathname.lastIndexOf("/") + 1,
+  );
+
+  const { fetch } = fetchPonyfill();
+
+  const sendRestPayload = async (
+    path: string,
+    payload: Record<string, any>,
+  ): Promise<any> => {
+    if (error) {
+      throw new Error(error);
+    }
+    const { maxRetries, retryInterval, retryJitter } = config;
+    if (origin && apiKey) {
+      const endpoint = new URL(origin);
+      endpoint.search = new URLSearchParams(payload).toString();
+      endpoint.pathname = apiKey + path;
+      for (let i = 0; i < maxRetries + 1; i++) {
+        const response = await fetch(endpoint.href);
+        const { status } = response;
+        switch (status) {
+          case 200:
+            return response.json();
+          case 429:
+            break;
+          default:
+            throw new Error(response.status + ":" + response.statusText);
+        }
+        await delay(retryInterval + ((retryJitter * Math.random()) | 0));
+      }
+      throw new Error(
+        `Rate limited for ${maxRetries + 1} consecutive attempts.`,
+      );
+    }
+    return Promise.resolve();
+  };
+
+  return {
+    sendRestPayload,
+  };
+}

--- a/test/alchemySubscriptions.test.ts
+++ b/test/alchemySubscriptions.test.ts
@@ -5,7 +5,7 @@ jest.mock("../src/web3-adapter/alchemyContext", () => {
     makeAlchemyContext: () => {
       return {
         provider: {},
-        senders: [],
+        jsonRpcSenders: [],
         setWriteProvider: {},
       };
     },

--- a/test/subscriptionBackfill.test.ts
+++ b/test/subscriptionBackfill.test.ts
@@ -8,13 +8,13 @@ import { fromHex, toHex } from "../src/util/hex";
 import { JsonRpcSenders } from "../src/util/jsonRpc";
 import { Mocked } from "./testUtils";
 
-let senders: Mocked<JsonRpcSenders>;
+let jsonRpcSenders: Mocked<JsonRpcSenders>;
 let getNewHeadsBackfill: Backfiller["getNewHeadsBackfill"];
 const isCancelled = () => false;
 
 beforeEach(() => {
-  senders = { send: jest.fn(), sendBatch: jest.fn() };
-  ({ getNewHeadsBackfill } = makeBackfiller(senders));
+  jsonRpcSenders = { send: jest.fn(), sendBatch: jest.fn() };
+  ({ getNewHeadsBackfill } = makeBackfiller(jsonRpcSenders));
 });
 
 describe("getNewHeadsBackfill", () => {
@@ -24,8 +24,8 @@ describe("getNewHeadsBackfill", () => {
       makeNewHeadsEvent(11, "b"),
       makeNewHeadsEvent(12, "c"),
     ];
-    senders.send.mockResolvedValue(toHex(12));
-    senders.sendBatch.mockResolvedValue(heads);
+    jsonRpcSenders.send.mockResolvedValue(toHex(12));
+    jsonRpcSenders.sendBatch.mockResolvedValue(heads);
     const result = await getNewHeadsBackfill(isCancelled, [], 9);
     expect(result).toEqual(heads);
     expectGetBlockRangeCalled(10, 13);
@@ -37,8 +37,8 @@ describe("getNewHeadsBackfill", () => {
       makeNewHeadsEvent(11, "b"),
     ];
     const expected = [makeNewHeadsEvent(12, "c"), makeNewHeadsEvent(13, "d")];
-    senders.sendBatch.mockResolvedValue(expected);
-    senders.send
+    jsonRpcSenders.sendBatch.mockResolvedValue(expected);
+    jsonRpcSenders.send
       .mockResolvedValueOnce(toHex(13))
       .mockResolvedValueOnce(makeNewHeadsEvent(11, "b"));
     const result = await getNewHeadsBackfill(isCancelled, previousHeads, 9);
@@ -54,8 +54,8 @@ describe("getNewHeadsBackfill", () => {
       makeNewHeadsEvent(12, "c"),
     ];
     const newHeads = [makeNewHeadsEvent(13, "d"), makeNewHeadsEvent(14, "e")];
-    senders.sendBatch.mockResolvedValue(newHeads);
-    senders.send
+    jsonRpcSenders.sendBatch.mockResolvedValue(newHeads);
+    jsonRpcSenders.send
       .mockResolvedValueOnce(toHex(14))
       .mockResolvedValueOnce(makeNewHeadsEvent(12, "c'"))
       .mockResolvedValueOnce(makeNewHeadsEvent(11, "b'"))
@@ -81,8 +81,8 @@ describe("getNewHeadsBackfill", () => {
       makeNewHeadsEvent(12, "c"),
     ];
     const newHeads = [makeNewHeadsEvent(13, "d"), makeNewHeadsEvent(14, "e")];
-    senders.sendBatch.mockResolvedValue(newHeads);
-    senders.send
+    jsonRpcSenders.sendBatch.mockResolvedValue(newHeads);
+    jsonRpcSenders.send
       .mockResolvedValueOnce(toHex(14))
       .mockResolvedValueOnce(makeNewHeadsEvent(12, "c'"))
       .mockResolvedValueOnce(makeNewHeadsEvent(11, "b'"))
@@ -105,7 +105,9 @@ describe("getNewHeadsBackfill", () => {
 
 function expectGetBlockCalled(blockNumber: number): void {
   expect(
-    senders.send.mock.calls.some((call) => fromHex(call[0]) === blockNumber),
+    jsonRpcSenders.send.mock.calls.some(
+      (call) => fromHex(call[0]) === blockNumber,
+    ),
   );
 }
 
@@ -113,8 +115,8 @@ function expectGetBlockRangeCalled(
   startInclusive: number,
   endExclusive: number,
 ): void {
-  expect(senders.sendBatch).toBeCalled();
-  const requestedBlockNumbers = senders.sendBatch.mock.calls[0][0].map(
+  expect(jsonRpcSenders.sendBatch).toBeCalled();
+  const requestedBlockNumbers = jsonRpcSenders.sendBatch.mock.calls[0][0].map(
     (request: JsonRpcRequest) => fromHex(request.params![0]),
   );
   const expectedRange: number[] = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -7085,10 +7085,10 @@ web3-bzz@1.3.6:
     swarm-js "^0.1.40"
     underscore "1.12.1"
 
-web3-bzz@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.5.2.tgz#a04feaa19462cff6d5a8c87dad1aca4619d9dfc8"
-  integrity sha512-W/sPCdA+XQ9duUYKHAwf/g69cbbV8gTCRsa1MpZwU7spXECiyJ2EvD/QzAZ+UpJk3GELXFF/fUByeZ3VRQKF2g==
+web3-bzz@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.6.0.tgz#584b51339f21eedff159abc9239b4b7ef6ded840"
+  integrity sha512-ugYV6BsinwhIi0CsLWINBz4mqN9wR9vNG0WmyEbdECjxcPyr6vkaWt4qi0zqlUxEnYAwGj4EJXNrbjPILntQTQ==
   dependencies:
     "@types/node" "^12.12.6"
     got "9.6.0"
@@ -7103,13 +7103,13 @@ web3-core-helpers@1.3.6:
     web3-eth-iban "1.3.6"
     web3-utils "1.3.6"
 
-web3-core-helpers@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.5.2.tgz#b6bd5071ca099ba3f92dfafb552eed2b70af2795"
-  integrity sha512-U7LJoeUdQ3aY9t5gU7t/1XpcApsWm+4AcW5qKl/44ZxD44w0Dmsq1c5zJm3GuLr/a9MwQfXK4lpmvxVQWHHQRg==
+web3-core-helpers@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.6.0.tgz#77e161b6ba930a4008a0df804ab379e0aa7e1e7f"
+  integrity sha512-H/IAH/0mrgvad/oxVKiAMC7qDzMrPPe/nRKmJOoIsupRg9/frvL62kZZiHhqVD1HMyyswbQFC69QRl7JqWzvxg==
   dependencies:
-    web3-eth-iban "1.5.2"
-    web3-utils "1.5.2"
+    web3-eth-iban "1.6.0"
+    web3-utils "1.6.0"
 
 web3-core-method@1.3.6:
   version "1.3.6"
@@ -7123,17 +7123,17 @@ web3-core-method@1.3.6:
     web3-core-subscriptions "1.3.6"
     web3-utils "1.3.6"
 
-web3-core-method@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-core-method/-/web3-core-method-1.5.2.tgz#d1d602657be1000a29d11e3ca3bf7bc778dea9a5"
-  integrity sha512-/mC5t9UjjJoQmJJqO5nWK41YHo+tMzFaT7Tp7jDCQsBkinE68KsUJkt0jzygpheW84Zra0DVp6q19gf96+cugg==
+web3-core-method@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-core-method/-/web3-core-method-1.6.0.tgz#ebe4ea51f5a4fa809bb68185576186359d3982e9"
+  integrity sha512-cHekyEil4mtcCOk6Q1Zh4y+2o5pTwsLIxP6Bpt4BRtZgdsyPiadYJpkLAVT/quch5xN7Qs5ZwG5AvRCS3VwD2g==
   dependencies:
     "@ethereumjs/common" "^2.4.0"
     "@ethersproject/transactions" "^5.0.0-beta.135"
-    web3-core-helpers "1.5.2"
-    web3-core-promievent "1.5.2"
-    web3-core-subscriptions "1.5.2"
-    web3-utils "1.5.2"
+    web3-core-helpers "1.6.0"
+    web3-core-promievent "1.6.0"
+    web3-core-subscriptions "1.6.0"
+    web3-utils "1.6.0"
 
 web3-core-promievent@1.3.6:
   version "1.3.6"
@@ -7142,10 +7142,10 @@ web3-core-promievent@1.3.6:
   dependencies:
     eventemitter3 "4.0.4"
 
-web3-core-promievent@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.5.2.tgz#2dc9fe0e5bbeb7c360fc1aac5f12b32d9949a59b"
-  integrity sha512-5DacbJXe98ozSor7JlkTNCy6G8945VunRRkPxMk98rUrg60ECVEM/vuefk1atACzjQsKx6tmLZuHxbJQ64TQeQ==
+web3-core-promievent@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.6.0.tgz#8b6053ae83cb47164540167fc361469fc604d2dd"
+  integrity sha512-ZzsevjMXWkhqW9dnVfTfb1OUcK7jKcKPvPIbQ4boJccNgvNZPZKlo8xB4pkAX38n4c59O5mC7Lt/z2QL/M5CeQ==
   dependencies:
     eventemitter3 "4.0.4"
 
@@ -7161,16 +7161,16 @@ web3-core-requestmanager@1.3.6:
     web3-providers-ipc "1.3.6"
     web3-providers-ws "1.3.6"
 
-web3-core-requestmanager@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-core-requestmanager/-/web3-core-requestmanager-1.5.2.tgz#43ccc00779394c941b28e6e07e217350fd1ded71"
-  integrity sha512-oRVW9OrAsXN2JIZt68OEg1Mb1A9a/L3JAGMv15zLEFEnJEGw0KQsGK1ET2kvZBzvpFd5G0EVkYCnx7WDe4HSNw==
+web3-core-requestmanager@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-core-requestmanager/-/web3-core-requestmanager-1.6.0.tgz#8ef3a3b89cd08983bd94574f9c5893f70a8a6aea"
+  integrity sha512-CY5paPdiDXKTXPWaEUZekDfUXSuoE2vPxolwqzsvKwFWH5+H1NaXgrc+D5HpufgSvTXawTw0fy7IAicg8+PWqA==
   dependencies:
     util "^0.12.0"
-    web3-core-helpers "1.5.2"
-    web3-providers-http "1.5.2"
-    web3-providers-ipc "1.5.2"
-    web3-providers-ws "1.5.2"
+    web3-core-helpers "1.6.0"
+    web3-providers-http "1.6.0"
+    web3-providers-ipc "1.6.0"
+    web3-providers-ws "1.6.0"
 
 web3-core-subscriptions@1.3.6:
   version "1.3.6"
@@ -7181,13 +7181,13 @@ web3-core-subscriptions@1.3.6:
     underscore "1.12.1"
     web3-core-helpers "1.3.6"
 
-web3-core-subscriptions@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.5.2.tgz#8eaebde44f81fc13c45b555c4422fe79393da9cf"
-  integrity sha512-hapI4rKFk22yurtIv0BYvkraHsM7epA4iI8Np+HuH6P9DD0zj/llaps6TXLM9HyacLBRwmOLZmr+pHBsPopUnQ==
+web3-core-subscriptions@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.6.0.tgz#8c23b15b434a7c9f937652ecca45d7108e2c54df"
+  integrity sha512-kY9WZUY/m1URSOv3uTLshoZD9ZDiFKReIzHuPUkxFpD5oYNmr1/aPQNPCrrMxKODR7UVX/D90FxWwCYqHhLaxQ==
   dependencies:
     eventemitter3 "4.0.4"
-    web3-core-helpers "1.5.2"
+    web3-core-helpers "1.6.0"
 
 web3-core@1.3.6:
   version "1.3.6"
@@ -7202,18 +7202,18 @@ web3-core@1.3.6:
     web3-core-requestmanager "1.3.6"
     web3-utils "1.3.6"
 
-web3-core@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.5.2.tgz#ca2b9b1ed3cf84d48b31c9bb91f7628f97cfdcd5"
-  integrity sha512-sebMpQbg3kbh3vHUbHrlKGKOxDWqjgt8KatmTBsTAWj/HwWYVDzeX+2Q84+swNYsm2DrTBVFlqTErFUwPBvyaA==
+web3-core@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.6.0.tgz#144eb00f651c9812faf7176abd7ee99d5f45e212"
+  integrity sha512-o0WsLrJ2yD+HAAc29lGMWJef/MutTyuzpJC0UzLJtIAQJqtpDalzWINEu4j8XYXGk34N/V6vudtzRPo23QEE6g==
   dependencies:
     "@types/bn.js" "^4.11.5"
     "@types/node" "^12.12.6"
     bignumber.js "^9.0.0"
-    web3-core-helpers "1.5.2"
-    web3-core-method "1.5.2"
-    web3-core-requestmanager "1.5.2"
-    web3-utils "1.5.2"
+    web3-core-helpers "1.6.0"
+    web3-core-method "1.6.0"
+    web3-core-requestmanager "1.6.0"
+    web3-utils "1.6.0"
 
 web3-eth-abi@1.3.6:
   version "1.3.6"
@@ -7224,13 +7224,13 @@ web3-eth-abi@1.3.6:
     underscore "1.12.1"
     web3-utils "1.3.6"
 
-web3-eth-abi@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.5.2.tgz#b627eada967f39ae4657ddd61b693cb00d55cb29"
-  integrity sha512-P3bJbDR5wib4kWGfVeBKBVi27T+AiHy4EJxYM6SMNbpm3DboLDdisu9YBd6INMs8rzxgnprBbGmmyn4jKIDKAA==
+web3-eth-abi@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.6.0.tgz#4225608f61ebb0607d80849bb2b20f910780253d"
+  integrity sha512-fImomGE9McuTMJLwK8Tp0lTUzXqCkWeMm00qPVIwpJ/h7lCw9UFYV9+4m29wSqW6FF+FIZKwc6UBEf9dlx3orA==
   dependencies:
     "@ethersproject/abi" "5.0.7"
-    web3-utils "1.5.2"
+    web3-utils "1.6.0"
 
 web3-eth-accounts@1.3.6:
   version "1.3.6"
@@ -7249,10 +7249,10 @@ web3-eth-accounts@1.3.6:
     web3-core-method "1.3.6"
     web3-utils "1.3.6"
 
-web3-eth-accounts@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-eth-accounts/-/web3-eth-accounts-1.5.2.tgz#cf506c21037fa497fe42f1f055980ce4acf83731"
-  integrity sha512-F8mtzxgEhxfLc66vPi0Gqd6mpscvvk7Ua575bsJ1p9J2X/VtuKgDgpWcU4e4LKeROQ+ouCpAG9//0j9jQuij3A==
+web3-eth-accounts@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-eth-accounts/-/web3-eth-accounts-1.6.0.tgz#530927f4c5b78df93b3ea1203abbb467de29cd04"
+  integrity sha512-2f6HS4KIH4laAsNCOfbNX3dRiQosqSY2TRK86C8jtAA/QKGdx+5qlPfYzbI2RjG81iayb2+mVbHIaEaBGZ8sGw==
   dependencies:
     "@ethereumjs/common" "^2.3.0"
     "@ethereumjs/tx" "^3.2.1"
@@ -7261,10 +7261,10 @@ web3-eth-accounts@1.5.2:
     ethereumjs-util "^7.0.10"
     scrypt-js "^3.0.1"
     uuid "3.3.2"
-    web3-core "1.5.2"
-    web3-core-helpers "1.5.2"
-    web3-core-method "1.5.2"
-    web3-utils "1.5.2"
+    web3-core "1.6.0"
+    web3-core-helpers "1.6.0"
+    web3-core-method "1.6.0"
+    web3-utils "1.6.0"
 
 web3-eth-contract@1.3.6:
   version "1.3.6"
@@ -7281,19 +7281,19 @@ web3-eth-contract@1.3.6:
     web3-eth-abi "1.3.6"
     web3-utils "1.3.6"
 
-web3-eth-contract@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.5.2.tgz#ffbd799fd01e36596aaadefba323e24a98a23c2f"
-  integrity sha512-4B8X/IPFxZCTmtENpdWXtyw5fskf2muyc3Jm5brBQRb4H3lVh1/ZyQy7vOIkdphyaXu4m8hBLHzeyKkd37mOUg==
+web3-eth-contract@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.6.0.tgz#deb946867ad86d32bcbba899d733b681b25ea674"
+  integrity sha512-ZUtO77zFnxuFtrc+D+iJ3AzNgFXAVcKnhEYN7f1PNz/mFjbtE6dJ+ujO0mvMbxIZF02t9IZv0CIXRpK0rDvZAw==
   dependencies:
     "@types/bn.js" "^4.11.5"
-    web3-core "1.5.2"
-    web3-core-helpers "1.5.2"
-    web3-core-method "1.5.2"
-    web3-core-promievent "1.5.2"
-    web3-core-subscriptions "1.5.2"
-    web3-eth-abi "1.5.2"
-    web3-utils "1.5.2"
+    web3-core "1.6.0"
+    web3-core-helpers "1.6.0"
+    web3-core-method "1.6.0"
+    web3-core-promievent "1.6.0"
+    web3-core-subscriptions "1.6.0"
+    web3-eth-abi "1.6.0"
+    web3-utils "1.6.0"
 
 web3-eth-ens@1.3.6:
   version "1.3.6"
@@ -7310,19 +7310,19 @@ web3-eth-ens@1.3.6:
     web3-eth-contract "1.3.6"
     web3-utils "1.3.6"
 
-web3-eth-ens@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-eth-ens/-/web3-eth-ens-1.5.2.tgz#ecb3708f0e8e2e847e9d89e8428da12c30bba6a4"
-  integrity sha512-/UrLL42ZOCYge+BpFBdzG8ICugaRS4f6X7PxJKO+zAt+TwNgBpjuWfW/ZYNcuqJun/ZyfcTuj03TXqA1RlNhZQ==
+web3-eth-ens@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-eth-ens/-/web3-eth-ens-1.6.0.tgz#af13852168d56fa71b9198eb097e96fb93831c2a"
+  integrity sha512-AG24PNv9qbYHSpjHcU2pViOII0jvIR7TeojJ2bxXSDqfcgHuRp3NZGKv6xFvT4uNI4LEQHUhSC7bzHoNF5t8CA==
   dependencies:
     content-hash "^2.5.2"
     eth-ens-namehash "2.0.8"
-    web3-core "1.5.2"
-    web3-core-helpers "1.5.2"
-    web3-core-promievent "1.5.2"
-    web3-eth-abi "1.5.2"
-    web3-eth-contract "1.5.2"
-    web3-utils "1.5.2"
+    web3-core "1.6.0"
+    web3-core-helpers "1.6.0"
+    web3-core-promievent "1.6.0"
+    web3-eth-abi "1.6.0"
+    web3-eth-contract "1.6.0"
+    web3-utils "1.6.0"
 
 web3-eth-iban@1.3.6:
   version "1.3.6"
@@ -7332,13 +7332,13 @@ web3-eth-iban@1.3.6:
     bn.js "^4.11.9"
     web3-utils "1.3.6"
 
-web3-eth-iban@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.5.2.tgz#f390ad244ef8a6c94de7c58736b0b80a484abc8e"
-  integrity sha512-C04YDXuSG/aDwOHSX+HySBGb0KraiAVt+/l1Mw7y/fCUrKC/K0yYzMYqY/uYOcvLtepBPsC4ZfUYWUBZ2PO8Vg==
+web3-eth-iban@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.6.0.tgz#edbe46cedc5b148d53fa455edea6b4eef53b2be7"
+  integrity sha512-HM/bKBS/e8qg0+Eh7B8C/JVG+GkR4AJty17DKRuwMtrh78YsonPj7GKt99zS4n5sDLFww1Imu/ZIk3+K5uJCjw==
   dependencies:
     bn.js "^4.11.9"
-    web3-utils "1.5.2"
+    web3-utils "1.6.0"
 
 web3-eth-personal@1.3.6:
   version "1.3.6"
@@ -7352,17 +7352,17 @@ web3-eth-personal@1.3.6:
     web3-net "1.3.6"
     web3-utils "1.3.6"
 
-web3-eth-personal@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-eth-personal/-/web3-eth-personal-1.5.2.tgz#043335a19ab59e119ba61e3bd6c3b8cde8120490"
-  integrity sha512-nH5N2GiVC0C5XeMEKU16PeFP3Hb3hkPvlR6Tf9WQ+pE+jw1c8eaXBO1CJQLr15ikhUF3s94ICyHcfjzkDsmRbA==
+web3-eth-personal@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-eth-personal/-/web3-eth-personal-1.6.0.tgz#b75a61c0737b8b8bcc11d05db2ed7bfce7e4b262"
+  integrity sha512-8ohf4qAwbShf4RwES2tLHVqa+pHZnS5Q6tV80sU//bivmlZeyO1W4UWyNn59vu9KPpEYvLseOOC6Muxuvr8mFQ==
   dependencies:
     "@types/node" "^12.12.6"
-    web3-core "1.5.2"
-    web3-core-helpers "1.5.2"
-    web3-core-method "1.5.2"
-    web3-net "1.5.2"
-    web3-utils "1.5.2"
+    web3-core "1.6.0"
+    web3-core-helpers "1.6.0"
+    web3-core-method "1.6.0"
+    web3-net "1.6.0"
+    web3-utils "1.6.0"
 
 web3-eth@1.3.6:
   version "1.3.6"
@@ -7383,23 +7383,23 @@ web3-eth@1.3.6:
     web3-net "1.3.6"
     web3-utils "1.3.6"
 
-web3-eth@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-eth/-/web3-eth-1.5.2.tgz#0f6470df60a2a7d04df4423ca7721db8ed5ad72b"
-  integrity sha512-DwWQ6TCOUqvYyo7T20S7HpQDPveNHNqOn2Q2F3E8ZFyEjmqT4XsGiwvm08kB/VgQ4e/ANyq/i8PPFSYMT8JKHg==
+web3-eth@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-eth/-/web3-eth-1.6.0.tgz#4c9d5fb4eccf9f8744828281757e6ea76af58cbd"
+  integrity sha512-qJMvai//r0be6I9ghU24/152f0zgJfYC23TMszN3Y6jse1JtjCBP2TlTibFcvkUN1RRdIUY5giqO7ZqAYAmp7w==
   dependencies:
-    web3-core "1.5.2"
-    web3-core-helpers "1.5.2"
-    web3-core-method "1.5.2"
-    web3-core-subscriptions "1.5.2"
-    web3-eth-abi "1.5.2"
-    web3-eth-accounts "1.5.2"
-    web3-eth-contract "1.5.2"
-    web3-eth-ens "1.5.2"
-    web3-eth-iban "1.5.2"
-    web3-eth-personal "1.5.2"
-    web3-net "1.5.2"
-    web3-utils "1.5.2"
+    web3-core "1.6.0"
+    web3-core-helpers "1.6.0"
+    web3-core-method "1.6.0"
+    web3-core-subscriptions "1.6.0"
+    web3-eth-abi "1.6.0"
+    web3-eth-accounts "1.6.0"
+    web3-eth-contract "1.6.0"
+    web3-eth-ens "1.6.0"
+    web3-eth-iban "1.6.0"
+    web3-eth-personal "1.6.0"
+    web3-net "1.6.0"
+    web3-utils "1.6.0"
 
 web3-net@1.3.6:
   version "1.3.6"
@@ -7410,14 +7410,14 @@ web3-net@1.3.6:
     web3-core-method "1.3.6"
     web3-utils "1.3.6"
 
-web3-net@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.5.2.tgz#58915d7e2dad025d2a08f02c865f3abe61c48eff"
-  integrity sha512-VEc9c+jfoERhbJIxnx0VPlQDot8Lm4JW/tOWFU+ekHgIiu2zFKj5YxhURIth7RAbsaRsqCb79aE+M0eI8maxVQ==
+web3-net@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.6.0.tgz#2c28f8787073110a7c2310336889d2dad647e500"
+  integrity sha512-LFfG95ovTT2sNHkO1TEfsaKpYcxOSUtbuwHQ0K3G0e5nevKDJkPEFIqIcob40yiwcWoqEjENJP9Bjk8CRrZ99Q==
   dependencies:
-    web3-core "1.5.2"
-    web3-core-method "1.5.2"
-    web3-utils "1.5.2"
+    web3-core "1.6.0"
+    web3-core-method "1.6.0"
+    web3-utils "1.6.0"
 
 web3-providers-http@1.3.6:
   version "1.3.6"
@@ -7427,12 +7427,12 @@ web3-providers-http@1.3.6:
     web3-core-helpers "1.3.6"
     xhr2-cookies "1.1.0"
 
-web3-providers-http@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.5.2.tgz#94f95fe5572ca54aa2c2ffd42c63956436c9eb0a"
-  integrity sha512-dUNFJc9IMYDLZnkoQX3H4ZjvHjGO6VRVCqrBrdh84wPX/0da9dOA7DwIWnG0Gv3n9ybWwu5JHQxK4MNQ444lyA==
+web3-providers-http@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.6.0.tgz#8db4e589abf7197f5d65b12af1bf9726c45f4160"
+  integrity sha512-sNxHFNv3lnxpmULt34AS6M36IYB/Hzm2Et4yPNzdP1XE644D8sQBZQZaJQdTaza5HfrlwoqU6AOK935armqGuA==
   dependencies:
-    web3-core-helpers "1.5.2"
+    web3-core-helpers "1.6.0"
     xhr2-cookies "1.1.0"
 
 web3-providers-ipc@1.3.6:
@@ -7444,13 +7444,13 @@ web3-providers-ipc@1.3.6:
     underscore "1.12.1"
     web3-core-helpers "1.3.6"
 
-web3-providers-ipc@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.5.2.tgz#68a516883c998eeddf60df4cead77baca4fb4aaa"
-  integrity sha512-SJC4Sivt4g9LHKlRy7cs1jkJgp7bjrQeUndE6BKs0zNALKguxu6QYnzbmuHCTFW85GfMDjhvi24jyyZHMnBNXQ==
+web3-providers-ipc@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.6.0.tgz#6a3410fd47a67c4a36719fb97f99534ae12aac98"
+  integrity sha512-ETYdfhpGiGoWpmmSJnONvnPfd3TPivHEGjXyuX+L5FUsbMOVZj9MFLNIS19Cx/YGL8UWJ/8alLJoTcWSIdz/aA==
   dependencies:
     oboe "2.1.5"
-    web3-core-helpers "1.5.2"
+    web3-core-helpers "1.6.0"
 
 web3-providers-ws@1.3.6:
   version "1.3.6"
@@ -7462,13 +7462,13 @@ web3-providers-ws@1.3.6:
     web3-core-helpers "1.3.6"
     websocket "^1.0.32"
 
-web3-providers-ws@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.5.2.tgz#d336a93ed608b40cdcadfadd1f1bc8d32ea046e0"
-  integrity sha512-xy9RGlyO8MbJDuKv2vAMDkg+en+OvXG0CGTCM2BTl6l1vIdHpCa+6A/9KV2rK8aU9OBZ7/Pf+Y19517kHVl9RA==
+web3-providers-ws@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.6.0.tgz#dc15dc18c30089efda992015fd5254bd2b77af5f"
+  integrity sha512-eNRmlhOPCpuVYwBrKBBQRLGPFb4U1Uo44r9EWV69Cpo4gP6XeBTl6nkawhLz6DS0fq79apyPfItJVuSfAy77pA==
   dependencies:
     eventemitter3 "4.0.4"
-    web3-core-helpers "1.5.2"
+    web3-core-helpers "1.6.0"
     websocket "^1.0.32"
 
 web3-shh@1.3.6:
@@ -7481,15 +7481,15 @@ web3-shh@1.3.6:
     web3-core-subscriptions "1.3.6"
     web3-net "1.3.6"
 
-web3-shh@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-shh/-/web3-shh-1.5.2.tgz#a72a3d903c0708a004db94a72d934a302d880aea"
-  integrity sha512-wOxOcYt4Sa0AHAI8gG7RulCwVuVjSRS/M/AbFsea3XfJdN6sU13/syY7OdZNjNYuKjYTzxKYrd3dU/K2iqffVw==
+web3-shh@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-shh/-/web3-shh-1.6.0.tgz#838a3435dce1039f669a48e53e948062de197931"
+  integrity sha512-ymN0OFL81WtEeSyb+PFpuUv39fR3frGwsZnIg5EVPZvrOIdaDSFcGSLDmafUt0vKSubvLMVYIBOCskRD6YdtEQ==
   dependencies:
-    web3-core "1.5.2"
-    web3-core-method "1.5.2"
-    web3-core-subscriptions "1.5.2"
-    web3-net "1.5.2"
+    web3-core "1.6.0"
+    web3-core-method "1.6.0"
+    web3-core-subscriptions "1.6.0"
+    web3-net "1.6.0"
 
 web3-utils@1.3.6:
   version "1.3.6"
@@ -7505,14 +7505,14 @@ web3-utils@1.3.6:
     underscore "1.12.1"
     utf8 "3.0.0"
 
-web3-utils@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.5.2.tgz#150982dcb1918ffc54eba87528e28f009ebc03aa"
-  integrity sha512-quTtTeQJHYSxAwIBOCGEcQtqdVcFWX6mCFNoqnp+mRbq+Hxbs8CGgO/6oqfBx4OvxIOfCpgJWYVHswRXnbEu9Q==
+web3-utils@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.6.0.tgz#1975c5ee5b7db8a0836eb7004848a7cd962d1ddc"
+  integrity sha512-bgCAWAeQnJF035YTFxrcHJ5mGEfTi/McsjqldZiXRwlHK7L1PyOqvXiQLE053dlzvy1kdAxWl/sSSfLMyNUAXg==
   dependencies:
     bn.js "^4.11.9"
-    eth-lib "0.2.8"
     ethereum-bloom-filters "^1.0.6"
+    ethereumjs-util "^7.1.0"
     ethjs-unit "0.1.6"
     number-to-bn "1.7.0"
     randombytes "^2.1.0"
@@ -7531,18 +7531,18 @@ web3@*:
     web3-shh "1.3.6"
     web3-utils "1.3.6"
 
-web3@1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/web3/-/web3-1.5.2.tgz#736ca2f39048c63964203dd811f519400973e78d"
-  integrity sha512-aapKLdO8t7Cos6tZLeeQUtCJvTiPMlLcHsHHDLSBZ/VaJEucSTxzun32M8sp3BmF4waDEmhY+iyUM1BKvtAcVQ==
+web3@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/web3/-/web3-1.6.0.tgz#d8fa0cd9e7bf252f9fe43bb77dc42bc6671affde"
+  integrity sha512-rWpXnO88MiVX5yTRqMBCVKASxc7QDkXZZUl1D48sKlbX4dt3BAV+nVMVUKCBKiluZ5Bp8pDrVCUdPx/jIYai5Q==
   dependencies:
-    web3-bzz "1.5.2"
-    web3-core "1.5.2"
-    web3-eth "1.5.2"
-    web3-eth-personal "1.5.2"
-    web3-net "1.5.2"
-    web3-shh "1.5.2"
-    web3-utils "1.5.2"
+    web3-bzz "1.6.0"
+    web3-core "1.6.0"
+    web3-eth "1.6.0"
+    web3-eth-personal "1.6.0"
+    web3-net "1.6.0"
+    web3-shh "1.6.0"
+    web3-utils "1.6.0"
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
This adds support for 2 new rest endpoints: getNfts and getNftMetadata. Since these two endpoints are REST and not jsonRpc, I have also renamed a lot of variables to include jsonRpc for clarity. I have also added support for retries on 429 rate limit responses. Also note that these new REST endpoints only work with the new alchemy.com endpoints, not legacy alchemyapi.io endpoints. 