### PR TITLE
add getTransactionReceipts alchemy endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,24 @@ An object with the following fields:
   - `attributes`: (Optional) An array of attributes from the NFT metadata. Each attribute is a dictionary with unknown keys and values, as they depend directly on the contract.
 - `timeLastUpdated`: ISO timestamp of the last cache refresh for the information returned in the metadata field.
 
+
+### `web3.alchemy.getTransactionReceipts({blockNumber | blockHash})`
+
+Fetches all transaction receipts for a block number or a block hash.
+
+**Parameters:**
+- blockNumber - (hex) The block number to get transaction receipts for
+- blockHash - The block hash to get transaction receipts for
+
+Note that either `blockNumber` or `blockHash` can be set.
+
+**Returns:**
+- `{receipts: TransactionReceipt[]}`
+
+The returned object is a list of transaction receipts for each transaction in this block. See 
+[eth_getTransactionReceipt](https://docs.alchemy.com/alchemy/apis/ethereum/eth_gettransactionreceipt#returns)
+  for the payload of an individual transaction receipt.
+
 ### `web3.eth.subscribe("alchemy_fullPendingTransactions")`
 
 Subscribes to pending transactions, similar to the standard Web3 call

--- a/src/alchemy-apis/types.ts
+++ b/src/alchemy-apis/types.ts
@@ -1,3 +1,5 @@
+import { TransactionReceipt } from "web3-core";
+
 export interface TokenAllowanceParams {
   contract: string;
   owner: string;
@@ -133,6 +135,20 @@ export interface GetNftsResponse {
   ownedNfts: Nft[];
   pageKey?: string;
   totalCount: number;
+}
+
+export interface TransactionReceiptsBlockNumber {
+  blockNumber: string;
+}
+export interface TransactionReceiptsBlockHash {
+  blockHash: string;
+}
+export type TransactionReceiptsParams =
+  | TransactionReceiptsBlockNumber
+  | TransactionReceiptsBlockHash;
+
+export interface TransactionReceiptsResponse {
+  receipts: TransactionReceipt[] | null;
 }
 
 export interface Nft {

--- a/src/alchemy-apis/types.ts
+++ b/src/alchemy-apis/types.ts
@@ -148,7 +148,7 @@ export type TransactionReceiptsParams =
   | TransactionReceiptsBlockHash;
 
 export interface TransactionReceiptsResponse {
-  receipts: TransactionReceipt[] | null;
+  receipts: TransactionReceipt[];
 }
 
 export interface Nft {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import {
   TokenAllowanceResponse,
   TokenBalancesResponse,
   TokenMetadataResponse,
+  TransactionReceiptsParams,
+  TransactionReceiptsResponse,
 } from "./alchemy-apis/types";
 import {
   AlchemyWeb3Config,
@@ -68,6 +70,10 @@ export interface AlchemyMethods {
     params: GetNftsParams,
     callback?: Web3Callback<GetNftsResponse>,
   ): Promise<GetNftsResponse>;
+  getTransactionReceipts(
+    params: TransactionReceiptsParams,
+    callback?: Web3Callback<TransactionReceiptsResponse>,
+  ): Promise<TransactionReceiptsResponse>;
 }
 
 /**
@@ -191,6 +197,13 @@ export function createAlchemyWeb3(
         callback,
         params,
         path: "/v1/getNFTs/",
+      }),
+    getTransactionReceipts: (params: TransactionReceiptsParams, callback) =>
+      callAlchemyJsonRpcMethod({
+        jsonRpcSenders,
+        callback,
+        method: "alchemy_getTransactionReceipts",
+        params: [params],
       }),
   };
   patchSubscriptions(alchemyWeb3);

--- a/src/web3-adapter/alchemySendHttp.ts
+++ b/src/web3-adapter/alchemySendHttp.ts
@@ -34,7 +34,7 @@ export function makeJsonRpcHttpSender(url: string): AlchemySendJsonRpcFunction {
         return {
           status,
           type: "networkError",
-          message: (await response.json()).message,
+          message: (await response.json()).error?.message,
         };
     }
   };


### PR DESCRIPTION
Adds [TransactionRecipts API](https://docs.alchemy.com/alchemy/enhanced-apis/transaction-receipts-api).

Tested npm package locally on dummy app:
```ts
web3.alchemy
  .getTransactionReceipts({ blockNumber: "0xd796e0" })
  .then((res: TransactionReceiptsResponse) => {
    console.log(res);
  });

web3.alchemy
  .getTransactionReceipts({ 
    blockHash:
      "0x15481e27761bc2776c2cd82176f5d11d5ad0f0d33c26b657db3e9f5745864a18"
  })
  .then((res: TransactionReceiptsResponse) => {
    console.log(res);
  });
```

Resulting output (truncated):
```
{
  receipts: [
    {
      transactionHash: '0x38c46226dc90b42689a520f880e92182b324c46be2f76bdbcd679e259b9c0db9',
      blockHash: '0xd206645a625d7974ec3a54203fa23548b602c5e8e3c24eb74464bc911ad95aeb',
      blockNumber: '0xd796e0',
      contractAddress: null,
      cumulativeGasUsed: '0x5208',
      effectiveGasPrice: '0x2ef0418e6d',
      from: '0xea674fdde714fd979de3edf0f56aa9716b898ec8',
      gasUsed: '0x5208',
      logs: [],
      logsBloom: '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
      status: '0x1',
      to: '0xb072bac41ffd001a8eef642940dd899485b492bc',
      transactionIndex: '0x0',
      type: '0x2'
    },
    {
      transactionHash: '0x79d78b07d5c12f64676192c9671c2ae29d66b0434a44be1cc8c9a62898425ff0',
      blockHash: '0xd206645a625d7974ec3a54203fa23548b602c5e8e3c24eb74464bc911ad95aeb',
      blockNumber: '0xd796e0',
      contractAddress: null,
      cumulativeGasUsed: '0x1df99',
      effectiveGasPrice: '0x602b03ef35',
      from: '0x02686778d3570fbcf022bd60a47381e72f86c65a',
      gasUsed: '0x18d91',
      logs: [Array],
      logsBloom: '0x00200000000000000000000880000000000000000000000000010000000000000000000000000000000000000000000002000000080000000000020000000000000000000000000000000008000000200000000000000000000000008000000000000000000100000000000000000000000000000000000000000010000000000000000000000000004000000000000000000001000000080000004000000000000000000000000002010000000000008000000000010000000000000000000000000002000000000000000000000401000000000000001040000000000020002000200000000000000000000000000000000800000000400000000000000000',
      status: '0x1',
      to: '0x7a250d5630b4cf539739df2c5dacb4c659f2488d',
      transactionIndex: '0x1',
      type: '0x2'
    },
``` 
