### PR TITLE
Remove error when using alchemyapi.io API

### DIFF
--- a/src/web3-adapter/sendRestPayload.ts
+++ b/src/web3-adapter/sendRestPayload.ts
@@ -30,10 +30,6 @@ export function makeRestPayloadSender({
     error =
       "Alchemy specific rest endpoints are not available with a non Alchemy provider.";
   }
-  if (url.includes("alchemyapi.io")) {
-    error =
-      "Alchemy specific rest endpoints are not available with our legacy endpoints on alchemyapi.io, please switch over to alchemy.com";
-  }
 
   // Don't use the native `URL` class for this. It doesn't work in React Native.
   const urlObject = new URI(url);


### PR DESCRIPTION
- Remove error message when using still-functional alchemyapi.io server
  as the API

<hr/>

### The Problem
Hello all! I am a new alchemy user, and I just started running into an error while using this library.

This change was introduced in commit `bbeed08` just before the `1.1.11` release, and I started doing development with the library just this week. 

On my dashboard, I am given an alchemy url which points to `alchemyapi.io`, and there are no visible alternatives which match the suggested `alchemy.com` endpoints. As a user, I find it confusing that the URL given on my site doesn't match the URL which is accepted by the library.

Furthermore, switching my url to point to `alchemy.com` doesn't appear to be working for me (requests time out), and this library functions 100% perfectly if I just apply this proposed fix and continue to use `alchemyapi.io`.

Furthermore, I can find another chunk of adjacent code where there are still explicit checks for the `alchemyapi.io` endpoint, which leads me to believe that blocking the usage of `alchemyapi.io` might have been accidental/premature. 

https://github.com/alchemyplatform/alchemy-web3/blob/690b26396fe1e019a5dd4bcc486b3262e8d58d6a/src/web3-adapter/alchemyContext.ts#L91-L95

Not having visibility into your org, I apologize if this is part of an infrastructure change which you are in the middle of performing, but I hope you understand my confusion with this!



### Proposed Solution

My proposed solution is to just remove this, with a backup alternative of just turning the error into a `console.warn` with a deprecation warning. Removing it is preferable because my logs could get pretty noisy from the warning. 😅 