### PR TITLE
getTokenBalances: allow specifying "DEFAULT_TOKENS" by omitting contractAddresses param

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Returns token balances for a specific address given a list of contracts.
 **Parameters:**
 
 1. `address`: The address for which token balances will be checked.
-2. `contractAddresses`: An array of contract addresses.
+2. `contractAddresses`: An optional array of contract addresses. Not specifying this will return all token balances. 
 
 **Returns:**
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export * from "./alchemy-apis/types";
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_RETRY_INTERVAL = 1000;
 const DEFAULT_RETRY_JITTER = 250;
+const DEFAULT_CONTRACT_ADDRESS = "DEFAULT_TOKENS";
 
 export interface AlchemyWeb3 extends Web3 {
   alchemy: AlchemyMethods;
@@ -53,7 +54,7 @@ export interface AlchemyMethods {
   ): Promise<TokenAllowanceResponse>;
   getTokenBalances(
     address: string,
-    contractAddresses: string[],
+    contractAddresses?: string[],
     callback?: Web3Callback<TokenBalancesResponse>,
   ): Promise<TokenBalancesResponse>;
   getTokenMetadata(
@@ -157,7 +158,7 @@ export function createAlchemyWeb3(
         jsonRpcSenders,
         callback,
         method: "alchemy_getTokenBalances",
-        params: [address, contractAddresses],
+        params: [address, contractAddresses || DEFAULT_CONTRACT_ADDRESS],
         processResponse: processTokenBalanceResponse,
       }),
     getTokenMetadata: (address, callback) =>


### PR DESCRIPTION
The current API surface does not allow for specifying all tokens via `DEFAULT_TOKENS` in `getTokenBalances()` when writing in TS since `contractAddresses: string[]` does not allow for raw string inputs.

This PR adds the ability to fetch all tokens for a given address by omitting `contractAddresses`.

### Manual Tests
1. Omit `contractAddresses`
- Call: `web3.alchemy.getTokenBalances("0xc01512D16109e0913241B54fCbdc572AcDc90695")`
- Output: 
```
{
  address: '0xc01512D16109e0913241B54fCbdc572AcDc90695',
  tokenBalances: [
    {
      contractAddress: '0xdac17f958d2ee523a2206206994597c13d831ec7',
      tokenBalance: '0',
      error: null
    },
    {
      contractAddress: '0x15d4c048f83bd7e37d49ea4c83a07267ec4203da',
      tokenBalance: '0',
      error: null
    },
    ...
  ]
}

```

2. Empty `contractAddresses` array (matches Composer behavior)
- Call: `web3.alchemy.getTokenBalances("0xc01512D16109e0913241B54fCbdc572AcDc90695", [])`
- Output: `Error: (400)  Invalid method parameter(s).`