### PR TITLE
Accept alchemy.com as an Alchemy URL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -403,6 +403,9 @@ function toArrayKey(key: string): string {
   return endsWith(key, "[]") ? key : `${key}[]`;
 }
 
+/**
+ * Like `String#endsWith`, for older environments.
+ */
 function endsWith(s: string, ending: string): boolean {
   const index = s.lastIndexOf(ending);
   return index >= 0 && index === s.length - ending.length;

--- a/src/web3-adapter/alchemyContext.ts
+++ b/src/web3-adapter/alchemyContext.ts
@@ -91,5 +91,5 @@ function isNodeEnvironment(): boolean {
 }
 
 function isAlchemyUrl(url: string): boolean {
-  return url.indexOf("alchemyapi.io") >= 0;
+  return url.indexOf("alchemy.com") >= 0 || url.indexOf("alchemyapi.io") >= 0;
 }


### PR DESCRIPTION
We previously checked if a URL was an Alchemy URL by seeing if it
contained `alchemyapi.io`, our old domain. We now accept `alchemy.com`,
our new domain, as well.

This only affects metrics/logging.