### PR TITLE
Disallow legacy endpoints on L2 networks

### DIFF
--- a/src/web3-adapter/sendRestPayload.ts
+++ b/src/web3-adapter/sendRestPayload.ts
@@ -30,6 +30,10 @@ export function makeRestPayloadSender({
     error =
       "Alchemy specific rest endpoints are not available with a non Alchemy provider.";
   }
+  if (url.includes("alchemyapi.io") && !url.includes("eth-")) {
+    error =
+      "Alchemy specific rest endpoints on L2 networks are not available with our legacy endpoints on alchemyapi.io. Please switch over to alchemy.com";
+  }
 
   // Don't use the native `URL` class for this. It doesn't work in React Native.
   const urlObject = new URI(url);


### PR DESCRIPTION
While we transition towards the new `alchemy.com` endpoints rather than
`alchemyapi.io` endpoints, we are ready to fully transition on L2
networks but not yet on eth networks. For now, allow eth networks to
keep using the old endpoints but require the new endpoints for L2s.