### PR TITLE
Update TransactionReceipt type to match backend types

### DIFF
--- a/src/alchemy-apis/types.ts
+++ b/src/alchemy-apis/types.ts
@@ -1,5 +1,3 @@
-import { TransactionReceipt } from "web3-core";
-
 export interface TokenAllowanceParams {
   contract: string;
   owner: string;
@@ -149,6 +147,36 @@ export type TransactionReceiptsParams =
 
 export interface TransactionReceiptsResponse {
   receipts: TransactionReceipt[] | null;
+}
+
+export interface TransactionReceipt {
+  transactionHash: string;
+  blockHash: string;
+  blockNumber: string;
+  contractAddress: string | null;
+  cumulativeGasUsed: string;
+  effectiveGasPrice: string;
+  from: string;
+  gasUsed: string;
+  logs: Log[];
+  logsBloom: string;
+  root?: string;
+  status?: string;
+  to: string;
+  transactionIndex: string;
+  type: string;
+}
+
+export interface Log {
+  blockHash: string;
+  address: string;
+  logIndex: string;
+  data: string;
+  removed: boolean;
+  topics: string[];
+  blockNumber: string;
+  transactionHash: string;
+  transactionIndex: string;
 }
 
 export interface Nft {


### PR DESCRIPTION
Fixes #96.

Main change is to use types that match our backend's response types, rather than the default Web3.js types.

Tested in dummy app to check matching types. Also referenced ethers.js [types](https://github.com/ethers-io/ethers.js/blob/master/packages/abstract-provider/src.ts/index.ts#L89) for `TransactionReceipt` to check log types.