### PR TITLE
Add withMetadata typings and metadata response types for getNFTs()

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,18 +340,44 @@ An object with the following fields:
 - `owner`: The address that you want to fetch NFTs for.
 - `pageKey`: (Optional) A key to fetch the next page of results.
 - `contractAddresses`: (Optional) An array of contract addresses to filter the owner's results to.
+- `withMetadata`: (Optional) If `false`, the returned NFTs will omit metadata. Defaults to `true`.
 
 **Returns:**
 
-An object with the following fields:
+When metadata is included, the returned object has the following fields:
 
 - `ownedNfts`: An array of NFT objects that the address owns. Each NFT object has the following structure.
-  - `contract`:
-    - `address`: The address of the contract or collection that the NFT belongs to.
-  - `id`:
-    - `tokenId`: Raw token id.
-    - `tokenMetadata`:
-      - `tokenType`: The type of token being sent as part of the request (Can be one of ["erc721" | "erc1155"]).
+    - `contract`:
+        - `address`: The address of the contract or collection that the NFT belongs to.
+    - `id`:
+        - `tokenId`: Raw token id.
+        - `tokenMetadata`:
+            - `tokenType`: The type of token being sent as part of the request (Can be one of ["erc721" | "erc1155"]).
+    - `title`: The title of the NFT, or an empty string if no title is available.
+    - `description`: The descriptions of the NFT, or an empty string if no description is available.
+    - `tokenUri`: (Optional)
+        - `raw`: Uri representing the location of the NFT's original metadata blob. This is a backup for you to parse
+          when the `metadata` field is not automatically populated.
+        - `gateway`: Public gateway uri for the raw uri.
+    - `media`: (Optional) An array of objects with the following structure.
+        - `uri`: A `tokenUri` as described above.
+    - `metadata`: (Optional)
+        - `image`: (Optional) A uri string that should be usable in an <image> tag.
+        - `attributes`: (Optional) An array of attributes from the NFT metadata. Each attribute is a dictionary with
+          unknown keys and values, as they depend directly on the contract.
+    - `timeLastUpdated`: ISO timestamp of the last cache refresh for the information returned in the metadata field.
+- `pageKey`: (Optional) A key to fetch the next page of results, if applicable.
+- `totalCount`: The total number of NFTs in the result set.
+
+If metadata is omitted, an object with the following fields is returned:
+
+- `ownedNfts`: An array of NFT objects that the address owns. Each NFT object has the following structure.
+    - `contract`:
+        - `address`: The address of the contract or collection that the NFT belongs to.
+    - `id`:
+        - `tokenId`: Raw token id.
+        - `tokenMetadata`:
+            - `tokenType`: The type of token being sent as part of the request (Can be one of ["erc721" | "erc1155"]).
 - `pageKey`: (Optional) A key to fetch the next page of results, if applicable.
 - `totalCount`: The total number of NFTs in the result set.
 

--- a/src/alchemy-apis/types.ts
+++ b/src/alchemy-apis/types.ts
@@ -79,7 +79,7 @@ export interface AssetTransfersResult {
   rawContract: RawContract;
 }
 
-export interface NftMetadata {
+export interface NftMetadata extends Record<string, any> {
   image?: string;
   attributes?: Array<Record<string, any>>;
 }
@@ -112,7 +112,9 @@ export interface GetNftMetadataParams {
   tokenType?: "erc721" | "erc1155";
 }
 
-export interface GetNftMetadataResponse {
+export type GetNftMetadataResponse = NftWithMetadata;
+
+export interface NftWithMetadata {
   contract: NftContract;
   id: NftId;
   title: string;
@@ -123,13 +125,36 @@ export interface GetNftMetadataResponse {
   timeLastUpdated: string;
 }
 
+export interface Nft {
+  contract: NftContract;
+  id: NftId;
+  title: string;
+  description: string;
+  tokenUri?: TokenUri;
+  metadata?: NftWithMetadata;
+}
+
 export interface GetNftsParams {
   owner: string;
   pageKey?: string;
   contractAddresses?: string[];
+  withMetadata?: boolean;
+}
+
+export interface GetNftsParamsWithoutMetadata {
+  owner: string;
+  pageKey?: string;
+  contractAddresses?: string[];
+  withMetadata: false;
 }
 
 export interface GetNftsResponse {
+  ownedNfts: NftWithMetadata[];
+  pageKey?: string;
+  totalCount: number;
+}
+
+export interface GetNftsResponseWithoutMetadata {
   ownedNfts: Nft[];
   pageKey?: string;
   totalCount: number;
@@ -177,11 +202,6 @@ export interface Log {
   blockNumber: string;
   transactionHash: string;
   transactionIndex: string;
-}
-
-export interface Nft {
-  contract: NftContract;
-  id: NftId;
 }
 
 export interface ERC1155Metadata {

--- a/src/alchemy-apis/types.ts
+++ b/src/alchemy-apis/types.ts
@@ -80,6 +80,8 @@ export interface AssetTransfersResult {
 }
 
 export interface NftMetadata extends Record<string, any> {
+  name?: string;
+  description?: string;
   image?: string;
   attributes?: Array<Record<string, any>>;
 }
@@ -112,11 +114,9 @@ export interface GetNftMetadataParams {
   tokenType?: "erc721" | "erc1155";
 }
 
-export type GetNftMetadataResponse = NftWithMetadata;
+export type GetNftMetadataResponse = NftMetadata;
 
-export interface NftWithMetadata {
-  contract: NftContract;
-  id: NftId;
+export interface Nft extends BaseNft {
   title: string;
   description: string;
   tokenUri?: TokenUri;
@@ -125,13 +125,9 @@ export interface NftWithMetadata {
   timeLastUpdated: string;
 }
 
-export interface Nft {
+export interface BaseNft {
   contract: NftContract;
   id: NftId;
-  title: string;
-  description: string;
-  tokenUri?: TokenUri;
-  metadata?: NftWithMetadata;
 }
 
 export interface GetNftsParams {
@@ -149,13 +145,13 @@ export interface GetNftsParamsWithoutMetadata {
 }
 
 export interface GetNftsResponse {
-  ownedNfts: NftWithMetadata[];
+  ownedNfts: Nft[];
   pageKey?: string;
   totalCount: number;
 }
 
 export interface GetNftsResponseWithoutMetadata {
-  ownedNfts: Nft[];
+  ownedNfts: BaseNft[];
   pageKey?: string;
   totalCount: number;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,9 @@ import {
   GetNftMetadataParams,
   GetNftMetadataResponse,
   GetNftsParams,
+  GetNftsParamsWithoutMetadata,
   GetNftsResponse,
+  GetNftsResponseWithoutMetadata,
   TokenAllowanceParams,
   TokenAllowanceResponse,
   TokenBalancesResponse,
@@ -70,9 +72,13 @@ export interface AlchemyMethods {
     callback?: Web3Callback<GetNftMetadataResponse>,
   ): Promise<GetNftMetadataResponse>;
   getNfts(
-    params: GetNftsParams,
-    callback?: Web3Callback<GetNftsResponse>,
-  ): Promise<GetNftsResponse>;
+    params: GetNftsParams | GetNftsParamsWithoutMetadata,
+    callback?: Web3Callback<GetNftsResponse | GetNftsResponseWithoutMetadata>,
+  ): Promise<GetNftsResponse | GetNftsResponseWithoutMetadata>;
+  getNfts(
+    params: GetNftsParamsWithoutMetadata,
+    callback?: Web3Callback<GetNftsResponseWithoutMetadata>,
+  ): Promise<GetNftsResponseWithoutMetadata>;
   getTransactionReceipts(
     params: TransactionReceiptsParams,
     callback?: Web3Callback<TransactionReceiptsResponse>,
@@ -194,7 +200,7 @@ export function createAlchemyWeb3(
         params,
         path: "/v1/getNFTMetadata/",
       }),
-    getNfts: (params: GetNftsParams, callback) =>
+    getNfts: (params: GetNftsParams | GetNftsParamsWithoutMetadata, callback) =>
       callAlchemyRestEndpoint({
         restSender,
         callback,


### PR DESCRIPTION
Fixes #99, Fixes #101.

This PR adds the `withMetadata` param to `getNfts()` and updates the return types to include the NFT metadata by default. This means that this PR should only be merged after @niveda-krish's changes to make `withMetadata=true` the default are pushed to prod.

I separated out `GetNftsResponse` to`GetNftsResponseWithoutMetadata` to give developers an easier way to reason about the types when `withMetadata` is set to `false`. 

I initially wanted to have two overloads for `withMetadata=false` and the default case in order to have better type completion. However, since the methods are defined on an object, I don't think overloads are possible. I'd be down to explore refactoring the methods into a separate class.

### Testing Plan
I verified manually that changes compile and ran a few API calls on a contract with the different overloads.
