### PR TITLE
Fix contractAddress property on TokenBalanceSuccess and TokenBalanceFailure

### DIFF
--- a/src/alchemy-apis/types.ts
+++ b/src/alchemy-apis/types.ts
@@ -14,13 +14,13 @@ export interface TokenBalancesResponse {
 export type TokenBalance = TokenBalanceSuccess | TokenBalanceFailure;
 
 export interface TokenBalanceSuccess {
-  address: string;
+  contractAddress: string;
   tokenBalance: string;
   error: null;
 }
 
 export interface TokenBalanceFailure {
-  address: string;
+  contractAddress: string;
   tokenBalance: null;
   error: string;
 }


### PR DESCRIPTION
Fixes #116.

Small naming correction. Verified response property name is `contractAddress` after testing the endpoint.