### PR TITLE
Fix GetNftMetadataResponse typing

### DIFF
--- a/src/alchemy-apis/types.ts
+++ b/src/alchemy-apis/types.ts
@@ -114,7 +114,7 @@ export interface GetNftMetadataParams {
   tokenType?: "erc721" | "erc1155";
 }
 
-export type GetNftMetadataResponse = NftMetadata;
+export type GetNftMetadataResponse = Nft;
 
 export interface Nft extends BaseNft {
   title: string;


### PR DESCRIPTION
A call to `getNftMetadata` should return the full `Nft` object that contains an optional `NftMetadata` object. This also matches the backend response types.