### PR TITLE
Add middleware support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -243,11 +243,18 @@ export function createAlchemyWeb3(
 
 function fillInConfigDefaults({
   writeProvider = getWindowProvider(),
+  jsonRpcSenderMiddlewares = [],
   maxRetries = DEFAULT_MAX_RETRIES,
   retryInterval = DEFAULT_RETRY_INTERVAL,
   retryJitter = DEFAULT_RETRY_JITTER,
 }: AlchemyWeb3Config = {}): FullConfig {
-  return { writeProvider, maxRetries, retryInterval, retryJitter };
+  return {
+    writeProvider,
+    jsonRpcSenderMiddlewares,
+    maxRetries,
+    retryInterval,
+    retryJitter,
+  };
 }
 
 function getWindowProvider(): Provider | null {

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export function isSubscriptionEvent(
 
 export interface AlchemyWeb3Config {
   writeProvider?: Provider | null;
+  jsonRpcSenderMiddlewares?: JsonRpcSenderMiddleware[];
   maxRetries?: number;
   retryInterval?: number;
   retryJitter?: number;
@@ -86,3 +87,8 @@ export type SendJsonRpcFunction = (
 export interface TransactionsOptions {
   address?: string;
 }
+
+export type JsonRpcSenderMiddleware = (
+  req: SingleOrBatchRequest,
+  next: () => Promise<SingleOrBatchResponse>,
+) => Promise<SingleOrBatchResponse>;

--- a/src/web3-adapter/sendJsonRpcPayload.ts
+++ b/src/web3-adapter/sendJsonRpcPayload.ts
@@ -70,19 +70,11 @@ export function makeJsonRpcPayloadSender(
   const sendJsonRpcPayload = (
     payload: SingleOrBatchRequest,
   ): Promise<SingleOrBatchResponse> => {
-    let i = 0;
-    const getNext = () => {
-      let called = false;
-      const middleware = middlewares[i++];
-      return () => {
-        if (called) {
-          throw new Error(`Cannot call "next" in a middleware twice`);
-        }
-        called = true;
-        return middleware(payload, getNext());
-      };
+    const getNext = (i: number) => {
+      const middleware = middlewares[i];
+      return () => middleware(payload, getNext(i + 1));
     };
-    return getNext()();
+    return getNext(0)();
   };
 
   function setWriteProvider(writeProvider: Provider | null | undefined) {


### PR DESCRIPTION
Hello, thank you for this useful library. We were using ethers.js to listen to new logs on blockchain, but due to occasional websocket disconnection, we made research for solutions and found this library and decided to use it. Now we want to add our functionalities to the alchemy-web3 provider. Functionalities like monitoring, caching, I mean, middleware things. To do so, we added middleware support to the library. So now we can monitor our outgoing/incoming ws/http messages and cache them.

Example middleware for monitoring:
```ts
  ...
  createJsonRpcSenderMiddleware = (): JsonRpcSenderMiddleware => {
    return (request, next) => {
      const startedTime = Date.now();
      this.emit('request', request);
      return next().then((response) => {
        const executionTime = Date.now() - startedTime;
        this.emit('response', response, executionTime);
        return res;
      });
    };
  };
  ...
```

For caching:
```ts
const methodsNotToCache = ['eth_blockNumber', 'net_version', 'eth_call', 'eth_subscribe'];
const createAlchemyCacheMiddleware = async (cache: CacheInterface) => {
  return (request, next) => {
    if (methodsNotToCache.includes(request.method)) {
      return next();
    }
    const cached = await cache.get([request.method, request.params]);
    if (cached) {
      return {
        ...cached,
        id: request.id, // change id with requested id to treat as if we really went to the provider
                        // and to prevent incompatibility between requested id and responded id
      };
    }
    const response = next();
    await cache.set([request.method, request.params], response);
    return response;
  }
}
```
I removed some boring logics like checking if a request/response is batch, if it contains ids, etc to keep examples simple.

Usage:
```ts
const web3 = createAlchemyWeb3(wsUrl, {
  jsonRpcSenderMiddlewares: [
    monitor.createJsonRpcSenderMiddleware(),
    createAlchemyCacheMiddleware(new InMemoryCache()),
    // other middlewares
    // ...
  ],
});
```

We tested the feature with these 2 functionalities, it works perfectly. If you accept this PR, we can update the docs with your help.

In the future, maybe you can think of implementing internal caching which can be enabled with the library options.

Thanks!