### PR TITLE
Add balance field to BaseNft

### DIFF
--- a/src/alchemy-apis/types.ts
+++ b/src/alchemy-apis/types.ts
@@ -129,6 +129,7 @@ export interface Nft extends BaseNft {
 export interface BaseNft {
   contract: NftContract;
   id: NftId;
+  balance?: string;
 }
 
 export interface GetNftsParams {

--- a/src/alchemy-apis/types.ts
+++ b/src/alchemy-apis/types.ts
@@ -129,7 +129,7 @@ export interface Nft extends BaseNft {
 export interface BaseNft {
   contract: NftContract;
   id: NftId;
-  balance?: string;
+  balance: string;
 }
 
 export interface GetNftsParams {


### PR DESCRIPTION
Seems like the `balance` field returns when possible on a `BaseNft` object, through both the `getNFTs` call (with or without metadata). This is useful for determining the amount of the tokenId when referencing an `erc1155`. 

Adding this type makes it so that typescript does not throw errors.

Btw, is there a difference between `v1` and `v2` api? https://github.com/alchemyplatform/alchemy-web3/blob/1381e8e2183b6a11c98c008ba5c73cd11e8cd2c7/src/index.ts#L176. Current documentation on https://docs.alchemy.com/alchemy/enhanced-apis/nft-api/getnfts references `v2`. 

Thanks for this useful library!