### PR TITLE
Revert back to v1 on endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,7 @@ export function createAlchemyWeb3(
       restSender,
       callback,
       params,
-      path: "/v2/getNFTs/",
+      path: "/v1/getNFTs/",
     });
   }
 
@@ -224,7 +224,7 @@ export function createAlchemyWeb3(
         restSender,
         callback,
         params,
-        path: "/v2/getNFTMetadata/",
+        path: "/v1/getNFTMetadata/",
       }),
     getNfts,
     getTransactionReceipts: (params: TransactionReceiptsParams, callback) =>


### PR DESCRIPTION
The Alchemy NFT endpoint was switched to v2 in a previous PR, but the `alchemyapi.io` endpoints only support `v1`. v2 only exists on `g.alchemy.com`. 

Undoing the change here.