### PR TITLE
Fix the missing Transaction in the return type of subscribe

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ export interface AlchemyEth extends Eth {
       error: Error,
       item: Log | Syncing | BlockHeader | string | Transaction,
     ) => void,
-  ): Subscription<Log | BlockHeader | Syncing | string>;
+  ): Subscription<Log | BlockHeader | Syncing | string | Transaction>;
   getMaxPriorityFeePerGas(
     callback?: (error: Error, fee: string) => void,
   ): Promise<string>;


### PR DESCRIPTION
The return value of the subscription type alchemy_filteredFullPendingTransactions should contain the Trasaction type