### PR TITLE
Add alchemy_pendingTransactions support

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -88,6 +88,18 @@ export interface TransactionsOptions {
   address?: string;
 }
 
+export interface PendingTransactionsOptions {
+  fromAddress?: string | string[];
+  toAddress?: string | string[];
+  hashesOnly?: boolean;
+}
+
+export interface PendingTransactionsOptionsHashesOnly {
+  fromAddress?: string | string[];
+  toAddress?: string | string[];
+  hashesOnly: true;
+}
+
 export type JsonRpcSenderMiddleware = (
   req: SingleOrBatchRequest,
   next: () => Promise<SingleOrBatchResponse>,


### PR DESCRIPTION
Adding support for the new `alchemy_pendingTransactions` endpoint ([docs](https://docs.alchemy.com/alchemy/enhanced-apis/subscription-api-websockets#alchemy_pendingtransactions)). 
- Using the old subscription endpoints will now log a deprecated warning.
- Includes an overload for the `{hashesOnly: true}` return type.

Verified in dummy test app.

Fixes #138 