### PR TITLE
Require 'category' field in getAssetTransfers()

### DIFF
--- a/src/alchemy-apis/types.ts
+++ b/src/alchemy-apis/types.ts
@@ -41,7 +41,7 @@ export interface AssetTransfersParams {
   contractAddresses?: string[];
   excludeZeroValue?: boolean;
   maxCount?: number;
-  category?: AssetTransfersCategory[];
+  category: AssetTransfersCategory[];
   pageKey?: string;
 }
 


### PR DESCRIPTION
Fixes #144.

Updates `getAssetTransfers()` to reflect the [changelog](https://docs.alchemy.com/alchemy/documentation/changelog#06-27-2022)