### PR TITLE
Update README to reflect maintenance mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Web3 client extended with Alchemy and browser provider integration.
 
-## MAINTENANCE MODE
+## ⚠️ MAINTENANCE MODE ⚠️
 As of July 2022, this repo is now in maintenance mode. The new SDK based on ethers.js is now available on [GitHub](https://github.com/alchemyplatform/alchemy-sdk-js) or [NPM](https://www.npmjs.com/package/alchemy-sdk). It has feature parity with this library as well as better typing, more abstractions, and more documentation. 
 
 Going forward, updates to this library will be made on a best-effort basis. If you see a bug or have a feature request, please open an issue or pull request on the [Github issues](https://github.com/alchemyplatform/alchemy-web3/issues) section.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Web3 client extended with Alchemy and browser provider integration.
 
+## MAINTENANCE MODE
+As of July 2022, this repo is now in maintenance mode. The new SDK based on ethers.js is now available on [GitHub](https://github.com/alchemyplatform/alchemy-sdk-js) or [NPM](https://www.npmjs.com/package/alchemy-sdk). It has feature parity with this library as well as better typing, more abstractions, and more documentation. 
+
+Going forward, updates to this library will be made on a best-effort basis. If you see a bug or have a feature request, please open an issue or pull request on the [Github issues](https://github.com/alchemyplatform/alchemy-web3/issues) section.
+
 ## Introduction
 
 Alchemy Web3 provides website authors with a drop-in replacement for the


### PR DESCRIPTION
## Update
As of July 2022, this repo is now in maintenance mode. The new SDK based on ethers.js is now available on [GitHub](https://github.com/alchemyplatform/alchemy-sdk-js) or [NPM](https://www.npmjs.com/package/alchemy-sdk). It has feature parity with this library as well as better typing, more abstractions, and more documentation.

Going forward, updates to this library will be made on a best-effort basis. If you see a bug or have a feature request, please open an issue or pull request on the [Github issues](https://github.com/alchemyplatform/alchemy-web3/issues) section.